### PR TITLE
allow user to set schemaMigration container resources

### DIFF
--- a/charts/fhir-server/Chart.yaml
+++ b/charts/fhir-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for the LinuxForHealth FHIR Server
 name: fhir-server
-version: 0.8.0
+version: 0.8.1
 appVersion: 5.0.0
 dependencies:
   - name: postgresql
@@ -25,7 +25,7 @@ annotations:
   artifacthub.io/changes: |
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
+    - kind: fixed
+      description: schematool should use its own container resources config
     - kind: changed
-      description: renamed chart from ibm-fhir-server to just fhir-server
-    - kind: changed
-      description: updated images from ibmcom/ibm-fhir-* to ghcr.io/linuxforhealth/fhir-*
+      description: updated default requests and limits for schematool job

--- a/charts/fhir-server/README.md
+++ b/charts/fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
 
 # The LinuxForHealth FHIR Server Helm Chart
 
@@ -347,7 +347,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | schemaMigration.image.pullSecret | string | `"all-icr-io"` |  |
 | schemaMigration.image.repository | string | `"ghcr.io/linuxforhealth/fhir-schematool"` | The repository to pull the LinuxForHealth FHIR Schema Tool image from |
 | schemaMigration.image.tag | string | this chart's appVersion | LinuxForHealth FHIR Schema Tool container image tag |
-| schemaMigration.resources | object | `{}` | container resources for the schema migration job |
+| schemaMigration.resources | object | `{"limits":{"ephemeral-storage":"256Mi","memory":"256Mi"},"requests":{"ephemeral-storage":"64Mi","memory":"64Mi"}}` | container resources for the schema migration job |
 | schemaMigration.ttlSecondsAfterFinished | int | `100` | How many seconds to wait before cleaning up a finished schema migration job. This automatic clean-up can have unintended interactions with CI tools like ArgoCD; setting this value to nil will disable the feature. |
 | security.jwtValidation.audience | string | `"https://{{ tpl $.Values.ingress.hostname $ }}/fhir-server/api/v4"` |  |
 | security.jwtValidation.enabled | bool | `false` |  |

--- a/charts/fhir-server/templates/schematool.yaml
+++ b/charts/fhir-server/templates/schematool.yaml
@@ -65,7 +65,7 @@ spec:
             runAsUser: 1001
             runAsGroup: 1001
           resources:
-            {{ toYaml .Values.resources | nindent 12 }}
+            {{ toYaml .Values.schemaMigration.resources | nindent 12 }}
           volumeMounts:
           {{- with .Values.extraVolumeMounts }}
               {{- tpl . $ | nindent 12 }}

--- a/charts/fhir-server/values.yaml
+++ b/charts/fhir-server/values.yaml
@@ -246,7 +246,13 @@ schemaMigration:
     pullPolicy: IfNotPresent
     pullSecret: all-icr-io
   # -- container resources for the schema migration job
-  resources: {}
+  resources:
+    requests:
+      memory: "64Mi"
+      ephemeral-storage: "64Mi"
+    limits:
+      memory: "256Mi"
+      ephemeral-storage: "256Mi"
   # -- How many seconds to wait before cleaning up a finished schema migration job.
   # This automatic clean-up can have unintended interactions with CI tools like ArgoCD;
   # setting this value to nil will disable the feature.


### PR DESCRIPTION
and set reasonable defaults:
* memory request of 64 MiB
* memory limit of 256 MiB

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>